### PR TITLE
fix: clamp distance to max theoretical value

### DIFF
--- a/src/ibeacon_ble/__init__.py
+++ b/src/ibeacon_ble/__init__.py
@@ -9,6 +9,7 @@ from home_assistant_bluetooth import BluetoothServiceInfo
 
 UNPACK_IBEACON = struct.Struct(">HHb").unpack
 
+MAX_THEORETICAL_DISTANCE = 400.0
 
 APPLE_MFR_ID = 76
 IBEACON_FIRST_BYTE = 0x02
@@ -86,4 +87,4 @@ def calculate_distance_meters(power: int, rssi: int) -> float | None:
         distance = pow(ratio, 10)
     else:
         distance = cast(float, 0.89976 * pow(ratio, 7.7095) + 0.111)
-    return distance if distance < 1000 else None
+    return min(distance, MAX_THEORETICAL_DISTANCE)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -77,8 +77,9 @@ def test_not_parse_short_service_info():
 def tests_calculate_distance_meters():
     assert calculate_distance_meters(-59, -60) == 1.1352362990362899
     assert calculate_distance_meters(59, -60) == 1.183020818815412
-    assert calculate_distance_meters(12, -80) is None
+    assert calculate_distance_meters(12, -80) == 400.0
     assert calculate_distance_meters(59, 0) is None
-    assert calculate_distance_meters(-3, -100) is None
+    assert calculate_distance_meters(-3, -100) == 400.0
+    assert calculate_distance_meters(-3, -96) == 400.0
     assert calculate_distance_meters(-3, -3) == 1.01076
     assert calculate_distance_meters(-4, -3) == 0.056313514709472656


### PR DESCRIPTION
Some beacons report wildly incorrect transmit power at 1m
or they are violating fcc regs