### PR TITLE
fix: ignore random transient ibeacons

### DIFF
--- a/src/ibeacon_ble/__init__.py
+++ b/src/ibeacon_ble/__init__.py
@@ -89,6 +89,16 @@ def parse(service_info: BluetoothServiceInfo) -> iBeaconAdvertisement | None:
     if uuid_str in BANNED_UUIDS:
         return None
 
+    name = service_info.name
+    if len(name) == 18 and name[0] == "S" and name[17] == "C":
+        # If it starts with S and ends with C and the inner
+        # 16 characters are hex, it's a random transient
+        try:
+            int(name[1:17], 16)
+            return None
+        except ValueError:
+            pass
+
     (major, minor, power) = UNPACK_IBEACON(data[18:23])
     distance = calculate_distance_meters(power, service_info.rssi)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -65,6 +65,28 @@ IBEACON_ZERO_POWER = BluetoothServiceInfo(
     service_uuids=[],
     source="hci0",
 )
+RANDOM_TRANSIENT = BluetoothServiceInfo(
+    address="00:00:00:00:00:00",
+    rssi=-60,
+    name="S6da7c9389bd5452cC",
+    manufacturer_data={
+        76: b"\x02\x15t'\x8b\xda\xb6DE \x8f\x0cr\x0e\xaf\x05\x995\x00\x00[$\xc5"
+    },
+    service_data={},
+    service_uuids=[],
+    source="hci0",
+)
+SC_NOT_RANDOM_TRANSIENT = BluetoothServiceInfo(
+    address="00:00:00:00:00:00",
+    rssi=-60,
+    name="SISAHAPPYPERSONINC",
+    manufacturer_data={
+        76: b"\x02\x15t'\x8b\xda\xb6DE \x8f\x0cr\x0e\xaf\x05\x995\x00\x00[$\xc5"
+    },
+    service_data={},
+    service_uuids=[],
+    source="hci0",
+)
 
 
 def test_parse():
@@ -102,6 +124,16 @@ def test_not_parse_short_service_info():
 def test_ignore_tilt():
     parsed = parse(TILT_SERVICE_INFO)
     assert parsed is None
+
+
+def test_ignore_random_transient():
+    parsed = parse(RANDOM_TRANSIENT)
+    assert parsed is None
+
+
+def test_not_random_transient():
+    parsed = parse(SC_NOT_RANDOM_TRANSIENT)
+    assert parsed is not None
 
 
 def test_ibeacon_zero_power():


### PR DESCRIPTION
These keep getting reported and nobody seems to have any idea where they come from so they aren't providing much value so let's filter them out